### PR TITLE
Use consisntent external IP address.

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -3,24 +3,36 @@ package usocksd
 import (
 	"net"
 	"time"
+
+	"golang.org/x/net/context"
 )
 
 const (
-	dialTimeout = 10 * time.Second
+	dialTimeout       = 10 * time.Second
+	keepAliveInterval = 300 * time.Second
 )
 
-func CreateDialer(c *Config) func(network, addr string) (net.Conn, error) {
+func CreateDialer(c *Config) func(ctx context.Context, network, addr string) (net.Conn, error) {
 	if len(c.Outgoing.Addresses) == 0 {
-		return net.Dial
+		return func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return net.Dial(network, addr)
+		}
 	}
 
 	ag := NewAddressGroup(c.Outgoing.Addresses, c.Outgoing.DNSBLDomain)
-	return func(network, addr string) (net.Conn, error) {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		var hint uint32
+		t := ctx.Value("hint")
+		if t != nil {
+			hint = t.(uint32)
+		}
+
 		d := net.Dialer{
 			Timeout: dialTimeout,
 			LocalAddr: &net.TCPAddr{
-				IP: ag.PickAddress(),
+				IP: ag.PickAddress(hint),
 			},
+			KeepAlive: keepAliveInterval,
 		}
 		return d.Dial(network, addr)
 	}

--- a/hint.go
+++ b/hint.go
@@ -1,0 +1,18 @@
+package usocksd
+
+import (
+	"hash/fnv"
+
+	socks5 "github.com/cybozu-go/go-socks5"
+	"golang.org/x/net/context"
+)
+
+type rewrite struct{}
+
+// add context a hint for choosing an outgoing IP address.
+func (r rewrite) Rewrite(ctx context.Context, req *socks5.Request) (context.Context, *socks5.AddrSpec) {
+	hash := fnv.New32a()
+	hash.Write(req.RemoteAddr.IP)
+	hash.Write(req.DestAddr.IP)
+	return context.WithValue(ctx, "hint", hash.Sum32()), req.DestAddr
+}

--- a/ruleset.go
+++ b/ruleset.go
@@ -3,39 +3,40 @@ package usocksd
 import (
 	"strconv"
 
-	socks5 "github.com/armon/go-socks5"
+	socks5 "github.com/cybozu-go/go-socks5"
 	"github.com/cybozu-go/log"
+	"golang.org/x/net/context"
 )
 
 type ruleSet struct {
 	*Config
 }
 
-func (r ruleSet) Allow(req *socks5.Request) bool {
+func (r ruleSet) Allow(ctx context.Context, req *socks5.Request) (context.Context, bool) {
 	if req.Command != socks5.ConnectCommand {
-		return false
+		return ctx, false
 	}
 	if !r.allowFQDN(req.DestAddr.FQDN) {
 		log.Warn("denied access", map[string]interface{}{
 			"_client_ip": req.RemoteAddr.IP.String(),
 			"_fqdn":      req.DestAddr.FQDN,
 		})
-		return false
+		return ctx, false
 	}
 	if !r.allowIP(req.RemoteAddr.IP) {
 		log.Warn("denied access", map[string]interface{}{
 			"_client_ip": req.RemoteAddr.IP.String(),
 		})
-		return false
+		return ctx, false
 	}
 	if !r.allowPort(req.DestAddr.Port) {
 		log.Warn("denied access", map[string]interface{}{
 			"_client_ip": req.RemoteAddr.IP.String(),
 			"_dest_port": strconv.Itoa(req.DestAddr.Port),
 		})
-		return false
+		return ctx, false
 	}
-	return true
+	return ctx, true
 }
 
 // CreateRuleSet returns a RuleSet for socks5.

--- a/server.go
+++ b/server.go
@@ -4,17 +4,19 @@ import (
 	"fmt"
 	_log "log"
 
-	socks5 "github.com/armon/go-socks5"
+	socks5 "github.com/cybozu-go/go-socks5"
 	"github.com/cybozu-go/log"
 )
 
 func ListenAndServe(c *Config) error {
 	logger := _log.New(log.DefaultLogger().Writer(log.LvError), "", 0)
+	var rewriter rewrite
 
 	socksConfig := &socks5.Config{
-		Rules:  CreateRuleSet(c),
-		Logger: logger,
-		Dial:   CreateDialer(c),
+		Rules:    CreateRuleSet(c),
+		Rewriter: rewriter,
+		Logger:   logger,
+		Dial:     CreateDialer(c),
 	}
 	s, err := socks5.New(socksConfig)
 	if err != nil {


### PR DESCRIPTION
Formerly, AddressGroup.PickAddress() choosed an external IP address
in a round-robin fashion.  This behavior breaks some FTP servers
that require the same IP address for control and data connections
in passive mode.

By using golang.org/x/net/context, a fingerprint of the client
IP address is brought to dialing function which then choose the
same external IP address based on the fingerprint.
