### PR TITLE
socks: add Server.SilenceLogs

### DIFF
--- a/socks/server.go
+++ b/socks/server.go
@@ -74,6 +74,9 @@ type Server struct {
 	// The global environment is used if Env is nil.
 	Env *well.Environment
 
+	// SilenceLogs changes Info-level logs to Debug-level ones.
+	SilenceLogs bool
+
 	once   sync.Once
 	server well.Server
 	pool   *sync.Pool
@@ -195,5 +198,9 @@ func (s *Server) handleConnection(ctx context.Context, conn net.Conn) {
 		s.Logger.Error("proxy ends with an error", fields)
 		return
 	}
-	s.Logger.Info("proxy ends", fields)
+	if s.SilenceLogs {
+		s.Logger.Debug("proxy ends", fields)
+	} else {
+		s.Logger.Info("proxy ends", fields)
+	}
 }

--- a/socks/socks4.go
+++ b/socks/socks4.go
@@ -90,7 +90,11 @@ func (s *Server) handleSOCKS4(ctx context.Context, conn net.Conn, cmdByte byte) 
 
 	fields["dest_addr"] = destConn.RemoteAddr().String()
 	fields["src_addr"] = destConn.LocalAddr().String()
-	s.Logger.Info("proxy starts", fields)
+	if s.SilenceLogs {
+		s.Logger.Debug("proxy starts", fields)
+	} else {
+		s.Logger.Info("proxy starts", fields)
+	}
 	return destConn
 }
 

--- a/socks/socks5.go
+++ b/socks/socks5.go
@@ -84,7 +84,11 @@ func (s *Server) handleSOCKS5(ctx context.Context, conn net.Conn, nauth byte) ne
 
 	fields["dest_addr"] = destConn.RemoteAddr().String()
 	fields["src_addr"] = destConn.LocalAddr().String()
-	s.Logger.Info("proxy starts", fields)
+	if s.SilenceLogs {
+		s.Logger.Debug("proxy starts", fields)
+	} else {
+		s.Logger.Info("proxy starts", fields)
+	}
 	return destConn
 }
 


### PR DESCRIPTION
~~This commit changes the log severity from Info to Debug for "proxy starts" and "proxy ends" messages.~~

~~If this change breaks other applications, I'd suggest adding a new struct field `Server.SilenceLogs` to make this change opt-in.~~

**EDIT**: updated to add a new struct field `Server.SilenceLogs`. `SilenceLogs` changes the log severity from Info to Debug for "proxy starts" and "proxy ends" messages.